### PR TITLE
Protobuffs is a runtime dependency

### DIFF
--- a/src/katja.app.src
+++ b/src/katja.app.src
@@ -9,7 +9,8 @@
   ]},
   {applications, [
     kernel,
-    stdlib
+    stdlib,
+    profobuffs
   ]},
   {mod, {katja_app, []}},
   {env, []}


### PR DESCRIPTION
If I make a release with relx, a lack of protobuffs will result in a crash
