### PR TITLE
Handle {error, nxdomain} in katja_connection:maybe_connect_tcp/1

### DIFF
--- a/src/katja_connection.erl
+++ b/src/katja_connection.erl
@@ -177,7 +177,8 @@ maybe_connect_tcp(#connection_state{host=Host, port=Port, transport=Transport}=S
       {ok, S2};
     {error, Reason} when Reason == econnrefused orelse
                          Reason == closed orelse
-                         Reason == timeout ->
+                         Reason == timeout orelse
+                         Reason == nxdomain ->
       S2 = S#connection_state{tcp_socket=undefined},
       {ok, S2};
     {error, _Reason}=E -> E


### PR DESCRIPTION
katja might bring VM down if the error is not handled on start.